### PR TITLE
Fix i18n problem

### DIFF
--- a/server/fandogh/api/settings.py
+++ b/server/fandogh/api/settings.py
@@ -50,6 +50,7 @@ MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -108,8 +109,18 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/2.0/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'en'
 
+from django.utils.translation import ugettext_lazy as _
+
+LANGUAGES = (
+    ('en', _('English')),
+    ('fa', _('Persian')),
+)
+
+LOCALE_PATHS = (
+    os.path.join(BASE_DIR, 'locale'),
+)
 TIME_ZONE = 'UTC'
 
 USE_I18N = True

--- a/server/fandogh/api/urls.py
+++ b/server/fandogh/api/urls.py
@@ -14,6 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.conf.urls import url
+from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
 from django.urls import path, include
 
@@ -21,6 +22,8 @@ from user.views import TokenView, AccountView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+]
+urlpatterns += i18n_patterns(
     path('api/tokens', TokenView.as_view()),
     path('api/accounts', AccountView.as_view()),
     # path('api/apps', AppView.as_view()),
@@ -28,4 +31,5 @@ urlpatterns = [
     url(r'api/services', include('service.urls')),
     url(r'api/managed-services', include('service.managed_service_urls')),
     url(r'api/users/', include('user.urls')),
-]
+    prefix_default_language=False
+)

--- a/server/fandogh/locale/fa/LC_MESSAGES/django.po
+++ b/server/fandogh/locale/fa/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-06-18 07:50+0000\n"
+"POT-Creation-Date: 2018-06-26 09:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -24,7 +24,8 @@ msgstr "این آدرس ایمیل تکراری است"
 
 #: user/serializers.py:23
 msgid "This name already used by another account, please choose another name"
-msgstr "این نام قبلا توسط فرد دیگری استفاده شده است، لطفا نام دیگری انتخاب کنید"
+msgstr ""
+"این نام قبلا توسط فرد دیگری استفاده شده است، لطفا نام دیگری انتخاب کنید"
 
 #: user/serializers.py:45
 msgid "User doesn't exists"
@@ -46,7 +47,7 @@ msgstr "حساب‌کاربری با موفقیت ساخته شد"
 msgid "A user with current email or namespace exists"
 msgstr "کاربری با این ایمیل یا فضانام قبلا ساخته شده است"
 
-#: user/views.py:97 user/views.py:125
+#: user/views.py:97
 msgid "Your account has been activated"
 msgstr "حساب کاربری شما فعال شد"
 
@@ -61,3 +62,7 @@ msgstr "درخواست شما معتبر نیست"
 #: user/views.py:110
 msgid "An email containing account recovery instruction has been sent to you."
 msgstr "ایمیلی حاوی دستورالعملی بازیابی حساب کاربری برای شما ارسال شد"
+
+#: user/views.py:125
+msgid "Your password has been changed"
+msgstr "رمز عبور شما با موفقیت تغییر یافت"

--- a/server/fandogh/user/views.py
+++ b/server/fandogh/user/views.py
@@ -122,7 +122,7 @@ class OnetimeTokenView(APIView):
             User.objects.filter(id=serializer.validated_data['id']).update(
                 password=make_password(serializer.validated_data['new_password'])
             )
-            return GeneralResponse(_("Your account has been activated"))
+            return GeneralResponse(_("Your password has been changed"))
         except RecoveryToken.DoesNotExist:
             return GeneralResponse(_("Requested code does not exist"), status=404)
         except ValidationError:


### PR DESCRIPTION
I've changed url patterns in order to support multiple languages. it should work as follow:
- The default behavior, without language code is English, so fandogh_cli should be fine.
- prefixing url with /fa/ will cause the API to use Farsi language.