### PR TITLE
Feature/add username field

### DIFF
--- a/server/fandogh/locale/fa/LC_MESSAGES/django.po
+++ b/server/fandogh/locale/fa/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-07-01 04:24+0000\n"
+"POT-Creation-Date: 2018-07-01 09:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,18 +26,32 @@ msgstr "انگلیسی"
 msgid "Persian"
 msgstr "فارسی"
 
-#: user/serializers.py:27
+#: user/serializers.py:15
+#, fuzzy
+#| msgid ""
+#| "you can use lowercase english letters, digits, dash and dot in your "
+#| "username"
+msgid ""
+"Only lowercase english letters, digits, dash and dot are allowed in username"
+msgstr "فقط حروف انگلیسی، اعداد، خط تیره و نقطه در نام‌کاربری قابل‌قبول است"
+
+#: user/serializers.py:29
 msgid "Email address already exists"
 msgstr "این آدرس ایمیل تکراری است"
 
-#: user/serializers.py:29
+#: user/serializers.py:31
 msgid "Username already taken"
 msgstr "نام‌کاربری قبلا توسط فرد دیگری انتخاب شده"
 
-#: user/serializers.py:32
+#: user/serializers.py:34
 msgid "This name already used by another account, please choose another name"
-msgstr "این نام قبلا توسط فرد دیگری انتخاب شده، لطفا نام دیگری انتخاب کنید"
-"این نام قبلا توسط فرد دیگری استفاده شده است، لطفا نام دیگری انتخاب کنید"
+msgstr ""
+"این نام قبلا توسط فرد دیگری انتخاب شده، لطفا نام دیگری انتخاب کنیداین نام "
+"قبلا توسط فرد دیگری استفاده شده است، لطفا نام دیگری انتخاب کنید"
+
+#: user/serializers.py:72
+msgid "There is no user with this email/username"
+msgstr "هیچ کاربری با این ایمیل/نام‌کاربری وجود ندارد"
 
 #: user/views.py:34
 msgid "Username or password is wrong"

--- a/server/fandogh/user/serializers.py
+++ b/server/fandogh/user/serializers.py
@@ -12,7 +12,7 @@ from django.utils.translation import ugettext as _
 
 class UserSerializer(Serializer):
     username = serializers.RegexField(max_length=32, regex=r"^[a-zA-Z0-9\._]{3,32}$", error_messages={
-        'invalid': _("Only lowercase english letters, digits, underscore and dot are allowed in username")
+        'invalid': _("Only lowercase english letters, digits, underscores and dots are allowed in username")
     })
     email = serializers.EmailField()
     password = serializers.CharField(max_length=128)

--- a/server/fandogh/user/serializers.py
+++ b/server/fandogh/user/serializers.py
@@ -63,9 +63,9 @@ class OTTRequestSerializer(serializers.Serializer):
 
     def validate(self, attrs):
         attrs = super(OTTRequestSerializer, self).validate(attrs)
-        identifier = attrs['identifier'].split("+")[0]
+        identifier = attrs['identifier']
         if '@' in identifier:
-            user = User.objects.filter(email__startswith=identifier).first()
+            user = User.objects.filter(email=identifier).first()
         else:
             user = User.objects.filter(username=identifier).first()
         if user is None:

--- a/server/fandogh/user/serializers.py
+++ b/server/fandogh/user/serializers.py
@@ -61,13 +61,15 @@ class OTTRequestSerializer(serializers.Serializer):
 
     def validate(self, attrs):
         attrs = super(OTTRequestSerializer, self).validate(attrs)
-        user = User.objects.filter(Q(email=attrs['identifier']) | Q(username=attrs['identifier'])).first()
+        identifier = attrs['identifier'].split("+")[0]
+        user = User.objects.filter(Q(email__startswith=identifier) | Q(username=identifier)).first()
         if user is None:
             raise ValidationError({"identifier": ["There is no user with this email/username"]})
         return {
             "user": user,
             **attrs
         }
+
 
 class RecoverySerializer(serializers.Serializer):
     id = serializers.IntegerField()

--- a/server/fandogh/user/serializers.py
+++ b/server/fandogh/user/serializers.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext as _
 
 
 class UserSerializer(Serializer):
-    username = serializers.RegexField(max_length=32, regex=r"^[a-zA-Z0-9\.]{3,32}$", error_messages={
+    username = serializers.RegexField(max_length=32, regex=r"^[a-zA-Z0-9\._]{3,32}$", error_messages={
         'invalid': _("Only lowercase english letters, digits, dash and dot are allowed in username")
     })
     email = serializers.EmailField()

--- a/server/fandogh/user/serializers.py
+++ b/server/fandogh/user/serializers.py
@@ -12,7 +12,7 @@ from django.utils.translation import ugettext as _
 
 class UserSerializer(Serializer):
     username = serializers.RegexField(max_length=32, regex=r"^[a-zA-Z0-9\._]{3,32}$", error_messages={
-        'invalid': _("Only lowercase english letters, digits, dash and dot are allowed in username")
+        'invalid': _("Only lowercase english letters, digits, underscore and dot are allowed in username")
     })
     email = serializers.EmailField()
     password = serializers.CharField(max_length=128)

--- a/server/fandogh/user/serializers.py
+++ b/server/fandogh/user/serializers.py
@@ -62,7 +62,10 @@ class OTTRequestSerializer(serializers.Serializer):
     def validate(self, attrs):
         attrs = super(OTTRequestSerializer, self).validate(attrs)
         identifier = attrs['identifier'].split("+")[0]
-        user = User.objects.filter(Q(email__startswith=identifier) | Q(username=identifier)).first()
+        if '@' in identifier:
+            user = User.objects.filter(email__startswith=identifier).first()
+        else:
+            user = User.objects.filter(username=identifier).first()
         if user is None:
             raise ValidationError({"identifier": ["There is no user with this email/username"]})
         return {

--- a/server/fandogh/user/serializers.py
+++ b/server/fandogh/user/serializers.py
@@ -1,14 +1,17 @@
 from django.contrib.auth.models import User
+from django.db.models import Q
+from django.db.transaction import atomic
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import Serializer
 
 from user import models
-from user.models import EarlyAccessRequest
+from user.models import EarlyAccessRequest, Namespace
 from django.utils.translation import ugettext as _
 
 
 class UserSerializer(Serializer):
+    username = serializers.CharField(max_length=32)
     email = serializers.EmailField()
     password = serializers.CharField(max_length=128)
     namespace = serializers.CharField(max_length=20)
@@ -16,12 +19,31 @@ class UserSerializer(Serializer):
     class Meta:
         exclude = ('password',)
 
-    def validate(self, attrs):
-        if models.User.objects.filter(email=attrs['email']).exists():
-            raise ValidationError({'email': [_("Email address already exists")]})
+    def validate(self, attrs: dict):
+        attrs['username'] = str(attrs['username']).lower()
+        duplicate_user = models.User.objects.filter(Q(email=attrs['email']) | Q(username=attrs['username'])).first()
+        if isinstance(duplicate_user, User):
+            if duplicate_user.email == attrs['email']:
+                raise ValidationError({'email': [_("Email address already exists")]})
+            if duplicate_user.username == attrs['username']:
+                raise ValidationError({'username': [_("Username already taken")]})
         if models.Namespace.objects.filter(name=attrs['namespace']).exists():
-            raise ValidationError({'namespace': [_("This name already used by another account, please choose another name")]})
+            raise ValidationError(
+                {'namespace': [_("This name already used by another account, please choose another name")]}
+            )
         return attrs
+
+    def save(self, **kwargs):
+        with atomic():
+            u = User.objects.create_user(
+                email=self.validated_data['email'],
+                username=self.validated_data['username'],
+                password=self.initial_data['password'],
+                **kwargs
+            )
+            if u:
+                Namespace.objects.create(name=self.validated_data['namespace'], owner=u)
+            return u
 
 
 class EarlyAccessRequestSerializer(serializers.ModelSerializer):
@@ -34,17 +56,18 @@ class IdentitySerializer(serializers.Serializer):
     id = serializers.IntegerField()
 
 
-class EmailSerializer(serializers.Serializer):
-    email = serializers.EmailField()
+class OTTRequestSerializer(serializers.Serializer):
+    identifier = serializers.CharField()
 
     def validate(self, attrs):
-        attrs = super(EmailSerializer, self).validate(attrs)
-        try:
-            attrs['user'] = User.objects.get(email=attrs['email'])
-        except User.DoesNotExist:
-            raise ValidationError(_("User doesn't exists"))
-        return attrs
-
+        attrs = super(OTTRequestSerializer, self).validate(attrs)
+        user = User.objects.filter(Q(email=attrs['identifier']) | Q(username=attrs['identifier'])).first()
+        if user is None:
+            raise ValidationError({"identifier": ["There is no user with this email/username"]})
+        return {
+            "user": user,
+            **attrs
+        }
 
 class RecoverySerializer(serializers.Serializer):
     id = serializers.IntegerField()

--- a/server/fandogh/user/serializers.py
+++ b/server/fandogh/user/serializers.py
@@ -11,7 +11,9 @@ from django.utils.translation import ugettext as _
 
 
 class UserSerializer(Serializer):
-    username = serializers.RegexField(max_length=32, regex=r"^[a-zA-Z0-9\.]{3,32}$", )
+    username = serializers.RegexField(max_length=32, regex=r"^[a-zA-Z0-9\.]{3,32}$", error_messages={
+        'invalid': _("Only lowercase english letters, digits, dash and dot are allowed in username")
+    })
     email = serializers.EmailField()
     password = serializers.CharField(max_length=128)
     namespace = serializers.CharField(max_length=20)
@@ -67,7 +69,7 @@ class OTTRequestSerializer(serializers.Serializer):
         else:
             user = User.objects.filter(username=identifier).first()
         if user is None:
-            raise ValidationError({"identifier": ["There is no user with this email/username"]})
+            raise ValidationError({"identifier": [_("There is no user with this email/username")]})
         return {
             "user": user,
             **attrs

--- a/server/fandogh/user/tests.py
+++ b/server/fandogh/user/tests.py
@@ -82,6 +82,5 @@ class AccountRecovery(APITestCase):
         r = self.client.patch("/api/users/recovery-tokens/{}".format(rt.code),
                               data={"id": 1, "new_password": "new_test"})
         self.assertEqual(r.status_code, 200)
-        print(r.status_code)
         response = self.client.post("/api/tokens", data=dict(username="mahdi", password="new_test"))
         self.assertEqual(response.status_code, 200)

--- a/server/fandogh/user/tests.py
+++ b/server/fandogh/user/tests.py
@@ -8,6 +8,7 @@ from user.models import ActivationCode, RecoveryToken
 class RegisterTestCase(APITestCase):
     def test_create_user_with_duplicate_email_address_should_return_400(self):
         response = self.client.post("/api/accounts", {
+            "username": "mahdi",
             "email": "mahdi@test.co",
             "password": "some",
             "namespace": "ns1",
@@ -61,9 +62,15 @@ class AccountRecovery(APITestCase):
             password="testtset",
             email="mahdi@test.tset",
         )
-        response = self.client.post("/api/users/recovery-tokens", data={"email": "mahdi@test.tset"})
+        response = self.client.post("/api/users/recovery-tokens", data={"identifier": "mahdi@test.tset"})
         self.assertEqual(response.status_code, 200)
-        send_recovery_token.assert_called_once_with(u)
+        response = self.client.post("/api/users/recovery-tokens", data={"identifier": "mahdi"})
+        self.assertEqual(response.status_code, 200)
+        send_recovery_token.assert_has_calls([
+            mock.call(u),
+            mock.call(u),
+        ])
+
 
     def test_use_account_recovery_token(self):
         u = User.objects.create_user(
@@ -75,5 +82,6 @@ class AccountRecovery(APITestCase):
         r = self.client.patch("/api/users/recovery-tokens/{}".format(rt.code),
                               data={"id": 1, "new_password": "new_test"})
         self.assertEqual(r.status_code, 200)
+        print(r.status_code)
         response = self.client.post("/api/tokens", data=dict(username="mahdi", password="new_test"))
         self.assertEqual(response.status_code, 200)

--- a/server/fandogh/user/views.py
+++ b/server/fandogh/user/views.py
@@ -19,7 +19,7 @@ error_logger = logging.getLogger("error")
 
 class TokenView(ObtainJSONWebToken):
     def post(self, request):
-        data = {**request.data}
+        data = dict(username=request.data.get('username'), password=request.data.get('password'))
         if 'username' in data:
             data['username'] = str(data['username']).lower()
         serializer = self.get_serializer(data=data)

--- a/server/fandogh/user/views.py
+++ b/server/fandogh/user/views.py
@@ -1,23 +1,17 @@
 import logging
-
 from django.contrib.auth.hashers import make_password
 from django.utils.translation import ugettext as _
 from django.contrib.auth.models import User
-from django.db.transaction import atomic
-from django.http import QueryDict
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_jwt.views import ObtainJSONWebToken
-
-from common.response import ErrorResponse, GeneralResponse, ErrorListResponse
-from user.models import Namespace
-from .serializers import UserSerializer, EarlyAccessRequestSerializer
+from common.response import ErrorListResponse
 from common.response import ErrorResponse, GeneralResponse
-from user.models import Namespace, ActivationCode, RecoveryToken
+from user.models import ActivationCode, RecoveryToken
 from user.services import send_confirmation_email, send_recovery_token
-from .serializers import UserSerializer, EarlyAccessRequestSerializer, IdentitySerializer, EmailSerializer, \
+from .serializers import UserSerializer, EarlyAccessRequestSerializer, IdentitySerializer, OTTRequestSerializer, \
     RecoverySerializer
 
 error_logger = logging.getLogger("error")
@@ -25,13 +19,10 @@ error_logger = logging.getLogger("error")
 
 class TokenView(ObtainJSONWebToken):
     def post(self, request):
-        username = request.data.get("username", None)
-        if username:
-            if type(request.data) == QueryDict:
-                request.data._mutable = True
-            # request.data["username"] = normalize_email(username)
-        serializer = self.get_serializer(data=request.data)
-
+        data = {**request.data}
+        if 'username' in data:
+            data['username'] = str(data['username']).lower()
+        serializer = self.get_serializer(data=data)
         if serializer.is_valid():
             token = serializer.object.get('token')
             response_data = {
@@ -63,23 +54,14 @@ class AccountView(APIView):
         serialized = UserSerializer(data=request.data)
         if serialized.is_valid():
             try:
-                with atomic():
-                    u = User.objects.create_user(
-                        email=serialized.validated_data['email'],
-                        username=serialized.validated_data['email'],
-                        password=serialized.initial_data['password'],
-                        first_name='',
-                        last_name='',
-                        is_active=False,
-                    )
-                    if u:
-                        Namespace.objects.create(name=serialized.validated_data['namespace'], owner=u)
-                        # send_confirmation_email(u)
-                        return GeneralResponse(_("User has been registered successfully"), status=status.HTTP_201_CREATED)
+                u = serialized.save(first_name='', last_name='', is_active=False, )
+                send_confirmation_email(u)
+                return GeneralResponse(_("User has been registered successfully"), status=status.HTTP_201_CREATED)
             except Exception as e:
                 error_logger.error("Error in creating account. {}".format(e))
                 return GeneralResponse(
-                    _("A user with current email or namespace exists"), status=status.HTTP_400_BAD_REQUEST
+                    _("Sorry about this inconvenience, there is a problem in our side, we'll fix it soon"),
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR
                 )
         else:
             return ErrorListResponse(serialized.errors)
@@ -103,7 +85,7 @@ class ActivationView(APIView):
 
 class OnetimeTokenView(APIView):
     def post(self, request):
-        serializer = EmailSerializer(data=request.data)
+        serializer = OTTRequestSerializer(data=request.data)
         try:
             serializer.is_valid(raise_exception=True)
             send_recovery_token(serializer.validated_data['user'])


### PR DESCRIPTION
### What changed?
I've added `username` field in user APIs and we do not use email as username anymore, users should provide their custom username during registration from now on.

### :red_circle: Attention:   
We have a few backward **incompatible** changes in our User APIs in this PR:
- `POST: api/accounts` requires `username` field.
- `POST: api/users/recovery-tokens` uses `identifier` field instead of `email`, an identifier could be an email address or username.